### PR TITLE
Updated Windows Subsystem for Linux Page's Title and Description from LSW to WSL

### DIFF
--- a/commandline/WSL/about.md
+++ b/commandline/WSL/about.md
@@ -1,5 +1,5 @@
 ---
-title: Learn about the Linux subsystem for Windows
+title: Learn about the Windows Subsystem for Linux
 description: Learn more about how the Linux Subsystem for Windows works.
 keywords: BashOnWindows, bash, wsl, windows, windowssubsystem
 author: scooley

--- a/commandline/WSL/about.md
+++ b/commandline/WSL/about.md
@@ -1,6 +1,6 @@
 ---
 title: Learn about the Windows Subsystem for Linux
-description: Learn more about how the Linux Subsystem for Windows works.
+description: Learn more about how the Windows Subsystem for Linux works.
 keywords: BashOnWindows, bash, wsl, windows, windowssubsystem
 author: scooley
 ms.date: 7/11/2016


### PR DESCRIPTION
WSL's about page had a title and description that said "Linux Subsystem for Windows".  This PR updates it to be consistent with "Windows Subsystem for Linux"